### PR TITLE
Push docker image to docker hub automatically during release with git tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,9 @@ env:
 script:
   - make all
   - docker run --rm -v $(pwd):/project openpolicyagent/conftest test --policy dockerfile-security.rego Dockerfile
+
+deploy:
+  provider: script
+  script: bash scripts/docker-push.sh $TRAVIS_TAG
+  on:
+    tags: true

--- a/scripts/docker-hub-image-push.sh
+++ b/scripts/docker-hub-image-push.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+git_tag=$1
+
+if [ -z "$git_tag" ]
+then
+    echo "no git tag has been provided. usage: docker-hub-image-push.sh <git-tag>"
+    exit 1
+fi
+
+
+echo "Using the git tag '$git_tag' as dobby Docker image tag"
+
+set -e
+
+echo "Logging into Docker Hub using credentials..."
+docker login --username thecasualcoder --password $DOCKER_HUB_TOKEN
+
+echo "Building dobby Docker image..."
+docker build -t thecasualcoder/dobby -t karuppiah7890/dobby:$git_tag .
+
+echo "Pushing dobby Docker image..."
+docker push thecasualcoder/dobby


### PR DESCRIPTION
Push latest tag and versioned tag too

Fixes #8 

For this to work, we need to configure `DOCKER_HUB_TOKEN` environment variable in Travis CI repo settings. There's also an alternative - store the environment variable's value in an encrypted form in the Travis CI config but I didn't take that route in this PR. But that can be done too, but the maintainers need to do the encryption and add it as I don't have access to the keys for encrypting that info, only repo owners can do it for their repo Travis CI pipelines